### PR TITLE
Add support for custom mapping of field names in JQB JSON

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /jqb2jooq.iml
 /target
 .DS_Store
+/.idea/

--- a/pom.xml
+++ b/pom.xml
@@ -153,6 +153,24 @@
                     </excludes>
                 </configuration>
             </plugin>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>build-helper-maven-plugin</artifactId>
+                <version>3.0.0</version>
+                <executions>
+                    <execution>
+                        <phase>generate-test-sources</phase>
+                        <goals>
+                            <goal>add-test-source</goal>
+                        </goals>
+                        <configuration>
+                            <sources>
+                                <source>${project.build.directory}/generated-test-sources</source>
+                            </sources>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
         </plugins>
     </build>
 

--- a/src/main/java/io/kowalski/jqb2jooq/JQB2JOOQ.java
+++ b/src/main/java/io/kowalski/jqb2jooq/JQB2JOOQ.java
@@ -15,12 +15,12 @@ public class JQB2JOOQ {
 
     /**
      * parse performs the transformation of filter to condition.
-     * @param targetClass must be an Enum that implements {@link RuleTarget}
+     * @param targetBuilder produces an Enum that implements {@link RuleTarget}
      * @param jsonFilter is the raw Json String representation of the jQuery QueryBuilder filter deserialized into a Map
      * @return the JOOQ Condition equivalent of the provided Json filter
      */
-    public static Condition parse(final Class<? extends RuleTarget> targetClass, final Map<String, Object> jsonFilter) {
-        Filter filter = FilterParser.parseJSON(targetClass, jsonFilter);
+    public static Condition parse(final RuleTargetBuilder targetBuilder, final Map<String, Object> jsonFilter) {
+        Filter filter = FilterParser.parseJSON(targetBuilder, jsonFilter);
         return FilterTranslator.translate(filter);
     }
 

--- a/src/main/java/io/kowalski/jqb2jooq/RuleTarget.java
+++ b/src/main/java/io/kowalski/jqb2jooq/RuleTarget.java
@@ -19,12 +19,4 @@ public interface RuleTarget {
     // Getter Contract
     Field getField();
     Condition[] getImplicitConditions();
-
-    /**
-     * parse is accessed via reflection and will call your Enum's valueOf method
-     * @param value the rule id as it appears in jQuery QueryBuilder
-     * @return the parsed RuleTarget as defined by your Enumeration definition
-     */
-    RuleTarget parse(String value);
-
 }

--- a/src/main/java/io/kowalski/jqb2jooq/RuleTargetBuilder.java
+++ b/src/main/java/io/kowalski/jqb2jooq/RuleTargetBuilder.java
@@ -1,0 +1,5 @@
+package io.kowalski.jqb2jooq;
+
+public interface RuleTargetBuilder {
+    RuleTarget build(String name);
+}

--- a/src/test/java/io/kowalski/jqb2jooq/test/FilterConversionTest.java
+++ b/src/test/java/io/kowalski/jqb2jooq/test/FilterConversionTest.java
@@ -5,6 +5,7 @@ import com.google.gson.reflect.TypeToken;
 import com.zaxxer.hikari.HikariConfig;
 import com.zaxxer.hikari.HikariDataSource;
 import io.kowalski.jqb2jooq.JQB2JOOQ;
+import io.kowalski.jqb2jooq.RuleTargetBuilder;
 import io.kowalski.jqb2jooq.test.jooq.tables.pojos.Employees;
 import org.jooq.Condition;
 import org.jooq.DSLContext;
@@ -56,7 +57,7 @@ public class FilterConversionTest {
     @Test
     public void nameLike() {
         Map<String, Object> filter = jsonToMap(FULLNAME_EQUALS_FILTER);
-        Condition condition = JQB2JOOQ.parse(TestFilterTargets.class, filter);
+        Condition condition = JQB2JOOQ.parse(ruleTargetBuilder, filter);
 
         try (DSLContext dsl = DSL.using(dataSource, SQLDialect.H2)) {
             List<Employees> employees = dsl.select().from(EMPLOYEES)
@@ -70,7 +71,7 @@ public class FilterConversionTest {
     @Test
     public void dobBetween() {
         Map<String, Object> filter = jsonToMap(DOB_BETWEEN_FILTER);
-        Condition condition = JQB2JOOQ.parse(TestFilterTargets.class, filter);
+        Condition condition = JQB2JOOQ.parse(ruleTargetBuilder, filter);
 
         try (DSLContext dsl = DSL.using(dataSource, SQLDialect.H2)) {
             List<Employees> employees = dsl.select().from(EMPLOYEES)
@@ -83,7 +84,7 @@ public class FilterConversionTest {
     @Test
     public void salaryLessThanOrEqual() {
         Map<String, Object> filter = jsonToMap(SALARY_LESS_OR_EQUAL_FILTER);
-        Condition condition = JQB2JOOQ.parse(TestFilterTargets.class, filter);
+        Condition condition = JQB2JOOQ.parse(ruleTargetBuilder, filter);
 
         try (DSLContext dsl = DSL.using(dataSource, SQLDialect.H2)) {
             List<Employees> employees = dsl.select().from(EMPLOYEES)
@@ -97,7 +98,7 @@ public class FilterConversionTest {
     @Test
     public void nestedDOBHourly() {
         Map<String, Object> filter = jsonToMap(NESTED_DOB_HOURLY_FILTER);
-        Condition condition = JQB2JOOQ.parse(TestFilterTargets.class, filter);
+        Condition condition = JQB2JOOQ.parse(ruleTargetBuilder, filter);
 
         try (DSLContext dsl = DSL.using(dataSource, SQLDialect.H2)) {
             List<Employees> employees = dsl.select().from(EMPLOYEES)
@@ -111,7 +112,7 @@ public class FilterConversionTest {
     @Test
     public void lazyCompleteTestCoverageGrabBag() {
         Map<String, Object> filter = jsonToMap(GRAB_BAG_FILTER);
-        Condition condition = JQB2JOOQ.parse(TestFilterTargets.class, filter);
+        Condition condition = JQB2JOOQ.parse(ruleTargetBuilder, filter);
 
         try (DSLContext dsl = DSL.using(dataSource, SQLDialect.H2)) {
             List<Employees> employees = dsl.select().from(EMPLOYEES)
@@ -126,4 +127,5 @@ public class FilterConversionTest {
         return GSON.fromJson(json, MAP_TYPE);
     }
 
+    private static RuleTargetBuilder ruleTargetBuilder = name -> TestFilterTargets.valueOf(name.toUpperCase());
 }

--- a/src/test/java/io/kowalski/jqb2jooq/test/TestFilterTargets.java
+++ b/src/test/java/io/kowalski/jqb2jooq/test/TestFilterTargets.java
@@ -23,11 +23,6 @@ public enum TestFilterTargets implements RuleTarget {
     }
 
     @Override
-    public TestFilterTargets parse(String value) {
-        return TestFilterTargets.valueOf(value);
-    }
-
-    @Override
     public Field getField() {
         return field;
     }


### PR DESCRIPTION
This PR adds the support for custom mapping between field names in jQuery QueryBuilder JSON and enums implementing `RuleTarget` interface.